### PR TITLE
Fix README formatting and restore content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # WebNinja
 
-
-# setup
-
-## License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-=======
 WebNinja is a lightweight automation and scraping toolkit. Instead of writing
 Python code for each task, you describe the steps to perform in a JSON
 configuration file. The parser interprets this file and uses Selenium,
@@ -79,3 +73,6 @@ pytest
 
 The tests exercise the Selenium helpers, multiprocessing utilities and the HTML
 parsing logic.
+
+## License
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- restore expanded README content from commit ce05efa
- add MIT license notice at the end
- remove stray merge marker

## Testing
- `pytest` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_686c25f6d2ec832681a676b34009d84c